### PR TITLE
Add new predicates for value checks

### DIFF
--- a/src/predicates.py
+++ b/src/predicates.py
@@ -5,16 +5,16 @@ from src.rules import PropertyRules
 # Mapping of input predicates to the corresponding methods in PropertyRules
 PREDICATE_METHOD_MAP = {
     "exists": PropertyRules.has_parameter.__name__,
-    "matches": PropertyRules.is_parameter_value.__name__,
     "greater than": PropertyRules.is_parameter_value_greater_than.__name__,
     "less than": PropertyRules.is_parameter_value_less_than.__name__,
     "in range": PropertyRules.is_parameter_value_in_range.__name__,
     "in list": PropertyRules.is_parameter_value_in_list.__name__,
     "equal to": PropertyRules.is_equal_value.__name__,
+    "not equal to": PropertyRules.is_not_equal_value.__name__,
     "is true": PropertyRules.is_parameter_value_true.__name__,
     "is false": PropertyRules.is_parameter_value_false.__name__,
     "is like": PropertyRules.is_parameter_value_like.__name__,
     "identical to": PropertyRules.is_identical_value.__name__,
-    "not equal": PropertyRules.is_not_equal_value.__name__,
     "contains": PropertyRules.is_parameter_value_containing.__name__,
+    "does not contain": PropertyRules.is_parameter_value_not_containing.__name__,
 }

--- a/src/rules.py
+++ b/src/rules.py
@@ -61,6 +61,21 @@ class PropertyRules:
     """A collection of rules for processing parameters in Speckle objects."""
 
     @staticmethod
+    def is_parameter_value_not_containing(speckle_object: Base, parameter_name: str, substring: str) -> bool:
+        """Checks if parameter value does not contain the given substring.
+
+        Args:
+            speckle_object: The Speckle object to check
+            parameter_name: Name of the parameter to check
+            substring: The substring to look for
+
+        Returns:
+            bool: True if the parameter value does not contain the substring
+        """
+        # Invert the result of contains check
+        return not PropertyRules.is_parameter_value_containing(speckle_object, parameter_name, substring)
+
+    @staticmethod
     def is_parameter_value_containing(speckle_object: Base, parameter_name: str, substring: str) -> bool:
         """Checks if parameter value contains the given substring.
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -386,3 +386,32 @@ class TestParameterHandling:
         """Test handling of numeric strings in both wall versions."""
         wall_instance = request.getfixturevalue(wall)  # Retrieve fixture dynamically
         assert PropertyRules.is_equal_value(wall_instance, attribute, expected_value)
+
+    @pytest.mark.parametrize(
+        "param_name, substring, expected_result",
+        [
+            ("speckle_type", "Revit", True),  # Test basic substring match
+            ("speckle_type", "revit", True),  # Test case-insensitive
+            ("speckle_type", "NotPresent", False),  # Test no match
+            ("speckle_type", "", True),  # Test empty string
+            ("non_existent", "anything", False),  # Test non-existent parameter
+        ],
+    )
+    def test_parameter_value_contains(self, test_objects, param_name, substring, expected_result):
+        """Test substring matching on parameter values."""
+        v2_obj, _ = test_objects
+        assert PropertyRules.is_parameter_value_containing(v2_obj, param_name, substring) == expected_result
+
+    @pytest.mark.parametrize(
+        "param_name, substring, expected_result",
+        [
+            ("speckle_type", "Revit", False),  # Should fail as it does contain Revit
+            ("speckle_type", "NotPresent", True),  # Should pass as it doesn't contain
+            ("speckle_type", "", False),  # Should fail as empty string is contained
+            ("non_existent", "anything", True),  # Should pass as non-existent can't contain
+        ],
+    )
+    def test_parameter_value_not_contains(self, test_objects, param_name, substring, expected_result):
+        """Test negative substring matching on parameter values."""
+        v2_obj, _ = test_objects
+        assert PropertyRules.is_parameter_value_not_containing(v2_obj, param_name, substring) == expected_result


### PR DESCRIPTION
- Removed "matches" and "not equal" predicates.
- Added "not equal to" and "does not contain" predicates.
- Introduced a method to check if a parameter value does not contain a substring.